### PR TITLE
Tweaks to casperjs tests

### DIFF
--- a/IPython/html/tests/casperjs/test_cases/execute_code_cell.js
+++ b/IPython/html/tests/casperjs/test_cases/execute_code_cell.js
@@ -4,7 +4,7 @@
 casper.notebook_test(function () {
     this.evaluate(function () {
         var cell = IPython.notebook.get_cell(0);
-        cell.set_text('a=10; print a');
+        cell.set_text('a=10; print(a)');
         cell.execute();
     });
 

--- a/IPython/html/tests/casperjs/test_cases/merge_cells.js
+++ b/IPython/html/tests/casperjs/test_cases/merge_cells.js
@@ -10,7 +10,7 @@ casper.notebook_test(function() {
             
             IPython.notebook.insert_cell_below('code');
             var cell_two = IPython.notebook.get_selected_cell();
-            cell_two.set_text('print a');
+            cell_two.set_text('print(a)');
         };
         
         // merge_cell_above()
@@ -30,8 +30,8 @@ casper.notebook_test(function() {
         };
     });
     
-    this.test.assertEquals(output.above, 'a = 5\nprint a',
+    this.test.assertEquals(output.above, 'a = 5\nprint(a)',
                            'Successful insert_cell_above().');
-    this.test.assertEquals(output.below, 'a = 5\nprint a',
+    this.test.assertEquals(output.below, 'a = 5\nprint(a)',
                            'Successful insert_cell_below().');
 });

--- a/IPython/testing/iptest.py
+++ b/IPython/testing/iptest.py
@@ -30,7 +30,6 @@ from __future__ import print_function
 import glob
 import os
 import os.path as path
-import re
 import sys
 import warnings
 
@@ -160,7 +159,7 @@ have['zmq'] = test_for('zmq.pyzmq_version_info', min_zmq, callback=lambda x: x()
 
 test_group_names = ['parallel', 'kernel', 'kernel.inprocess', 'config', 'core',
                     'extensions', 'lib', 'terminal', 'testing', 'utils',
-                    'nbformat', 'qt', 'html', 'js', 'nbconvert'
+                    'nbformat', 'qt', 'html', 'nbconvert'
                    ]
 
 class TestSection(object):
@@ -283,9 +282,6 @@ if not have['jinja2']:
     sec.exclude('notebookapp')
 if not have['azure']:
     sec.exclude('services.notebooks.azurenbmanager')
-
-sec = test_sections['js']
-sec.requires('zmq', 'tornado', 'jinja2', 'casperjs')
 
 # config:
 # Config files aren't really importable stand-alone


### PR DESCRIPTION
- Using print() in tests
- The JSController shouldn't launch its server on creation, only as and when we go to use it.
- Some refactoring - my intention is that `test_sections` specifically describes nose test suites, with things like module inclusions and exclusions, and potentially other options in the future. The controller is the object that knows about running tests using a command line, so that's where information should be stored in the more general case. Each PyTestController corresponds to one TestSection, because we need that information on both sides of the process barrier.
