### PR TITLE
omit stack traces from particular files prototype

### DIFF
--- a/IPython/core/debugger.py
+++ b/IPython/core/debugger.py
@@ -364,6 +364,8 @@ class Pdb(OldPdb):
 
         #s = filename + '(' + `lineno` + ')'
         filename = self.canonic(frame.f_code.co_filename)
+        if 'tmp' in filename:
+            return  ''
         link = tpl_link % py3compat.cast_unicode(filename)
 
         if frame.f_code.co_name:

--- a/IPython/core/ultratb.py
+++ b/IPython/core/ultratb.py
@@ -744,6 +744,8 @@ class VerboseTB(TBTools):
 
             file = py3compat.cast_unicode(file, util_path.fs_encoding)
             link = tpl_link % file
+            if 'tmp' in file:
+                continue
             args, varargs, varkw, locals = inspect.getargvalues(frame)
 
             if func == '?':


### PR DESCRIPTION
@northisup 

there are two places to make changes - one for the stack trace as it is
printed by ipython on error, the other as it is printed by ipdb.

you can verify that it works like this: (note the missing `tmp.py` entries)

``` ipython
In [1]: !cat tmp.py                                                                                                                                                                                                                                                                                                                                                                                                  
import bar

def foo_test():
    bar_test()

def bar_test():
    bar.foo_bar()



In [2]: !cat bar.py

def foo_bar():
    1/0

In [3]: import tmp

In [4]: tmp.foo_test()
---------------------------------------------------------------------------
ZeroDivisionError                         Traceback (most recent call last)
<ipython-input-4-f50710bfc43f> in <module>()
----> 1 tmp.foo_test()

/Users/pi/code/ipython/bar.pyc in foo_bar()
      1 
      2 def foo_bar():
----> 3     1/0

ZeroDivisionError: integer division or modulo by zero

In [5]: debug
> /Users/pi/code/ipython/bar.py(3)foo_bar()
      1 
      2 def foo_bar():
----> 3     1/0

ipdb> w
  <ipython-input-4-f50710bfc43f>(1)<module>()
----> 1 tmp.foo_test()



> /Users/pi/code/ipython/bar.py(3)foo_bar()
      1 
      2 def foo_bar():
----> 3     1/0

ipdb> 
```
